### PR TITLE
rtmp

### DIFF
--- a/oss_c_sdk/oss_api.h
+++ b/oss_c_sdk/oss_api.h
@@ -677,16 +677,13 @@ aos_status_t *oss_gen_vod_play_list(const oss_request_options_t *options,
  * @param[in]   live_channel        the oss live channel name
  * @param[in]   play_list_name      the oss live channel play list name
  * @param[in]   expires             the end expire time for signed url
- * @param[in]   params              the user defined parameters in signed url,
- *                                  if none, fill NULL
  * @return  signed url, non-NULL success, NULL failure
  */
 char *oss_gen_rtmp_signed_url(const oss_request_options_t *options,
                               const aos_string_t *bucket,
                               const aos_string_t *live_channel,
                               const aos_string_t *play_list_name,
-                              const int64_t expires,
-                              aos_table_t *params);
+                              const int64_t expires);
 
 OSS_CPP_END
 

--- a/oss_c_sdk/oss_live.c
+++ b/oss_c_sdk/oss_live.c
@@ -330,14 +330,14 @@ char *oss_gen_rtmp_signed_url(const oss_request_options_t *options,
                               const aos_string_t *bucket,
                               const aos_string_t *live_channel,
                               const aos_string_t *play_list_name,
-                              const int64_t expires,
-                              aos_table_t *params)
+                              const int64_t expires)
 {
     aos_string_t signed_url;
     char *expires_str = NULL;
     aos_string_t expires_time;
     int res = AOSE_OK;
     aos_http_request_t *req = NULL;
+    aos_table_t *params = NULL;
 
     expires_str = apr_psprintf(options->pool, "%" APR_INT64_T_FMT, expires);
     aos_str_set(&expires_time, expires_str);

--- a/oss_c_sdk_test/test_oss_live.c
+++ b/oss_c_sdk_test/test_oss_live.c
@@ -639,7 +639,7 @@ void test_gen_rtmp_signed_url(CuTest *tc)
     aos_str_set(&play_list_name, "play.m3u8");
     expires = apr_time_now() / 1000000 + 60 * 30;
     rtmp_url = oss_gen_rtmp_signed_url(options, &bucket, &channel_name,
-        &play_list_name, expires, NULL);
+        &play_list_name, expires);
 
     // manual check passed
     CuAssertStrnEquals(tc, AOS_RTMP_PREFIX, strlen(AOS_RTMP_PREFIX), rtmp_url);


### PR DESCRIPTION
去除 oss_gen_rtmp_signed_url 接口中的param参数