### PR TITLE
fix signed url

### DIFF
--- a/oss_c_sdk/aos_http_io.c
+++ b/oss_c_sdk/aos_http_io.c
@@ -289,11 +289,6 @@ int aos_http_io_initialize(const char *user_agent_info, int flags)
     apr_snprintf(aos_user_agent, sizeof(aos_user_agent)-1, "%s(Compatible %s)", 
                  AOS_VER, user_agent_info);
 
-    if ((s = apr_file_open_stderr(&aos_stderr_file, aos_global_pool)) != APR_SUCCESS) {
-        aos_error_log("apr_file_open_stderr failure, code:%d %s.\n", s, apr_strerror(s, buf, sizeof(buf)));
-        return AOSE_INTERNAL_ERROR;
-    }
-
     req_options = aos_http_request_options_create(aos_global_pool);
     trans_options = aos_http_transport_options_create(aos_global_pool);
     trans_options->user_agent = aos_user_agent;

--- a/oss_c_sdk/aos_util.c
+++ b/oss_c_sdk/aos_util.c
@@ -82,13 +82,9 @@ int aos_url_encode(char *dest, const char *src, int maxSrcSize)
             return AOSE_INVALID_ARGUMENT;
         }
         c = *src;
-        if (isalnum(c) ||
-            (c == '-') || (c == '_') || (c == '.') || (c == '!') || 
-            (c == '~') || (c == '*') || (c == '\'') || (c == '(') ||
-            (c == ')') || (c == '/')) {
+        if (isalnum(c) || (c == '-') || (c == '_') || (c == '.') || (c == '~')) {
             *dest++ = c;
         } else if (*src == ' ') {
-            // *dest++ = '+';
             *dest++ = '%';
             *dest++ = '2';
             *dest++ = '0';

--- a/oss_c_sdk/oss_auth.c
+++ b/oss_c_sdk/oss_auth.c
@@ -24,6 +24,7 @@ static const char *g_s_oss_sub_resource_list[] = {
     "startTime",
     "endTime",
     "x-oss-process",
+    "security-token",
     NULL,
 };
 
@@ -354,13 +355,16 @@ int oss_get_signed_url(const oss_request_options_t *options,
     aos_string_t signature;
     const char *proto;
 
+    if (options->config->sts_token.data != NULL) {
+        apr_table_set(req->query_params, OSS_SECURITY_TOKEN, options->config->sts_token.data);
+    }
+
     res = get_oss_request_signature(options, req, expires, &signature);
     if (res != AOSE_OK) {
         return res;
     }
 
-    apr_table_set(req->query_params, OSS_ACCESSKEYID, 
-                  options->config->access_key_id.data);
+    apr_table_set(req->query_params, OSS_ACCESSKEYID, options->config->access_key_id.data);
     apr_table_set(req->query_params, OSS_EXPIRES, expires->data);
     apr_table_set(req->query_params, OSS_SIGNATURE, signature.data);
 

--- a/oss_c_sdk/oss_define.c
+++ b/oss_c_sdk/oss_define.c
@@ -31,6 +31,7 @@ const char OSS_POSITION[] = "position";
 const char OSS_MULTIPART_CONTENT_TYPE[] = "application/x-www-form-urlencoded";
 const char OSS_COPY_SOURCE[] = "x-oss-copy-source";
 const char OSS_COPY_SOURCE_RANGE[] = "x-oss-copy-source-range";
+const char OSS_SECURITY_TOKEN[] = "security-token";
 const char OSS_STS_SECURITY_TOKEN[] = "x-oss-security-token";
 const char OSS_REPLACE_OBJECT_META[] = "x-oss-replace-object-meta";
 const char OSS_OBJECT_TYPE[] = "x-oss-object-type";

--- a/oss_c_sdk/oss_define.h
+++ b/oss_c_sdk/oss_define.h
@@ -57,6 +57,7 @@ extern const char OSS_POSITION[];
 extern const char OSS_MULTIPART_CONTENT_TYPE[];
 extern const char OSS_COPY_SOURCE[];
 extern const char OSS_COPY_SOURCE_RANGE[];
+extern const char OSS_SECURITY_TOKEN[];
 extern const char OSS_STS_SECURITY_TOKEN[];
 extern const char OSS_REPLACE_OBJECT_META[];
 extern const char OSS_OBJECT_TYPE[];

--- a/oss_c_sdk/oss_object.c
+++ b/oss_c_sdk/oss_object.c
@@ -298,17 +298,15 @@ aos_status_t *oss_copy_object(const oss_request_options_t *options,
     query_params = aos_table_create_if_null(options, query_params, 0);
 
     /* init headers */
-    copy_source = apr_psprintf(options->pool, "/%.*s/%.*s", 
-                               source_bucket->len, source_bucket->data, 
-                               source_object->len, source_object->data);
-
-    res = aos_url_encode(buffer, copy_source, AOS_MAX_QUERY_ARG_LEN);
+    res = aos_url_encode(buffer, source_object->data, AOS_MAX_QUERY_ARG_LEN);
     if (res != AOSE_OK) {
         aos_status_set(s, res, AOS_URL_ENCODE_ERROR_CODE, NULL);
         return s;
     }
 
-    apr_table_set(headers, OSS_CANNONICALIZED_HEADER_COPY_SOURCE, buffer);
+    copy_source = apr_psprintf(options->pool, "/%.*s/%s", 
+        source_bucket->len, source_bucket->data, buffer);
+    apr_table_set(headers, OSS_CANNONICALIZED_HEADER_COPY_SOURCE, copy_source);
     set_content_type(NULL, dest_object->data, headers);
 
     oss_init_object_request(options, dest_bucket, dest_object, HTTP_PUT, 

--- a/oss_c_sdk/oss_util.c
+++ b/oss_c_sdk/oss_util.c
@@ -232,6 +232,7 @@ void oss_get_object_uri(const oss_request_options_t *options,
                 raw_endpoint.len, raw_endpoint.data);
         req->uri = object->data;
     }
+
 }
 
 void oss_get_bucket_uri(const oss_request_options_t *options, 
@@ -690,7 +691,6 @@ void oss_init_live_channel_request(const oss_request_options_t *options,
     oss_get_object_uri(options, bucket, live_channel, *req);
 }
 
-
 void oss_init_signed_url_request(const oss_request_options_t *options, 
                                  const aos_string_t *signed_url,
                                  http_method_e method, 
@@ -699,7 +699,11 @@ void oss_init_signed_url_request(const oss_request_options_t *options,
                                  aos_table_t *headers, 
                                  aos_http_response_t **resp)
 {
-    oss_init_request(options, method, req, params, headers, resp);
+    *req = aos_http_request_create(options->pool);
+    *resp = aos_http_response_create(options->pool);
+    (*req)->method = method;
+    (*req)->headers = headers;
+    (*req)->query_params = params;
     (*req)->signed_url = signed_url->data;
 }
 

--- a/oss_c_sdk_test/test_aos.c
+++ b/oss_c_sdk_test/test_aos.c
@@ -284,9 +284,9 @@ void test_aos_ends_with(CuTest *tc) {
 void test_aos_url_encode_failed(CuTest *tc) {
     int ret;
     char *dest;
-    dest = (char*)malloc(20);
+    dest = (char*)malloc(1024);
     
-    ret = aos_url_encode(dest, "abc.xx.com", 1);
+    ret = aos_url_encode(dest, "/mingdi-hz-3/./xxx/./ddd/", 1);
     CuAssertIntEquals(tc, AOSE_INVALID_ARGUMENT, ret);
 
     free(dest);
@@ -303,7 +303,7 @@ void test_aos_url_encode_with_blank_char(CuTest *tc) {
     
     ret = aos_url_encode(dest, source, strlen(source));
     CuAssertIntEquals(tc, AOSE_OK, ret);
-    CuAssertStrEquals(tc, "abc.xx.com/a%20b", dest);
+    CuAssertStrEquals(tc, "abc.xx.com%2Fa%20b", dest);
 
     free(dest);
 

--- a/oss_c_sdk_test/test_oss_image.c
+++ b/oss_c_sdk_test/test_oss_image.c
@@ -22,7 +22,7 @@ typedef struct {
 } image_info_t;
 
 #if defined(WIN32)
-static char *image_file = "../oss_c_sdk_test/example.jpg";
+static char *image_file = "..\\oss_c_sdk_test\\example.jpg";
 #else
 static char *image_file = "oss_c_sdk_test/example.jpg";
 #endif

--- a/oss_c_sdk_test/test_oss_multipart.c
+++ b/oss_c_sdk_test/test_oss_multipart.c
@@ -625,6 +625,8 @@ void test_list_upload_part_with_empty(CuTest *tc)
     aos_list_t complete_part_list;
     aos_table_t *complete_resp_headers = NULL;
     char *content_type_for_complete = "video/MP2T";
+    oss_list_part_content_t *part_content1 = NULL;
+    oss_complete_part_content_t *complete_content1 = NULL;
 
     aos_pool_create(&p, NULL);
     options = oss_request_options_create(p);
@@ -649,6 +651,14 @@ void test_list_upload_part_with_empty(CuTest *tc)
     CuAssertIntEquals(tc, 0, params->truncated);
     CuAssertStrEquals(tc, NULL, params->next_part_number_marker.data);
     CuAssertPtrNotNull(tc, list_part_resp_headers);
+
+    // test for #OSS-1161
+    aos_list_for_each_entry(oss_list_part_content_t, part_content1, &params->part_list, node) {
+        complete_content1 = oss_create_complete_part_content(p);
+        aos_str_set(&complete_content1->part_number, part_content1->part_number.data);
+        aos_str_set(&complete_content1->etag, part_content1->etag.data);
+        aos_list_add_tail(&complete_content1->node, &complete_part_list);
+    }
 
     //complete multipart
     apr_table_add(headers, OSS_CONTENT_TYPE, content_type_for_complete);


### PR DESCRIPTION
### 变更内容
- 添加：支持并发断点续传上传`oss_resumable_upload_file`
- 修复：`oss_gen_signed_url`支持临时用户签名
- 修复：初始化默认不打开`fd 2`，退出时不关闭`fd 2`
- 修复：修复key为`xxx/./yyy/`，`./async_test/test`报`SignatureDoesNotMatch`的问题