### PR TITLE
fix resumable upload

### DIFF
--- a/oss_c_sdk/oss_define.c
+++ b/oss_c_sdk/oss_define.c
@@ -33,7 +33,6 @@ const char OSS_COPY_SOURCE[] = "x-oss-copy-source";
 const char OSS_COPY_SOURCE_RANGE[] = "x-oss-copy-source-range";
 const char OSS_SECURITY_TOKEN[] = "security-token";
 const char OSS_STS_SECURITY_TOKEN[] = "x-oss-security-token";
-const char OSS_REPLACE_OBJECT_META[] = "x-oss-replace-object-meta";
 const char OSS_OBJECT_TYPE[] = "x-oss-object-type";
 const char OSS_NEXT_APPEND_POSITION[] = "x-oss-next-append-position";
 const char OSS_HASH_CRC64_ECMA[] = "x-oss-hash-crc64ecma";

--- a/oss_c_sdk/oss_define.h
+++ b/oss_c_sdk/oss_define.h
@@ -59,7 +59,6 @@ extern const char OSS_COPY_SOURCE[];
 extern const char OSS_COPY_SOURCE_RANGE[];
 extern const char OSS_SECURITY_TOKEN[];
 extern const char OSS_STS_SECURITY_TOKEN[];
-extern const char OSS_REPLACE_OBJECT_META[];
 extern const char OSS_OBJECT_TYPE[];
 extern const char OSS_NEXT_APPEND_POSITION[];
 extern const char OSS_HASH_CRC64_ECMA[];

--- a/oss_c_sdk/oss_multipart.c
+++ b/oss_c_sdk/oss_multipart.c
@@ -27,7 +27,7 @@ aos_status_t *oss_init_multipart_upload(const oss_request_options_t *options,
 
     //init headers
     headers = aos_table_create_if_null(options, headers, 1);
-    oss_set_multipart_content_type(headers);
+    set_content_type(NULL, object->data, headers);
 
     oss_init_object_request(options, bucket, object, HTTP_POST, 
                             &req, query_params, headers, NULL, 0, &resp);
@@ -194,8 +194,7 @@ aos_status_t *oss_do_complete_multipart_upload(const oss_request_options_t *opti
 
     //init headers
     headers = aos_table_create_if_null(options, headers, 1);
-    oss_set_multipart_content_type(headers);
-    apr_table_add(headers, OSS_REPLACE_OBJECT_META, OSS_YES);
+    apr_table_set(headers, OSS_CONTENT_TYPE, OSS_MULTIPART_CONTENT_TYPE);
 
     oss_init_object_request(options, bucket, object, HTTP_POST, 
                             &req, query_params, headers, NULL, 0, &resp);

--- a/oss_c_sdk/oss_util.c
+++ b/oss_c_sdk/oss_util.c
@@ -607,14 +607,6 @@ oss_list_live_channel_params_t *oss_create_list_live_channel_params(aos_pool_t *
     return params;
 }
 
-void oss_set_multipart_content_type(aos_table_t *headers)
-{
-    const char *content_type;
-    content_type = (char*)(apr_table_get(headers, OSS_CONTENT_TYPE));
-    content_type = content_type == NULL ? OSS_MULTIPART_CONTENT_TYPE : content_type;
-    apr_table_set(headers, OSS_CONTENT_TYPE, content_type);
-}
-
 const char *get_oss_acl_str(oss_acl_e oss_acl)
 {
     switch (oss_acl) {

--- a/oss_c_sdk/oss_util.h
+++ b/oss_c_sdk/oss_util.h
@@ -188,12 +188,6 @@ oss_upload_part_copy_params_t *oss_create_upload_part_copy_params(aos_pool_t *p)
 oss_upload_file_t *oss_create_upload_file(aos_pool_t *p);
 
 /**
-  * @brief  get content-type for HTTP_POST request
-  * @return content-type for HTTP_POST request
-**/
-void oss_set_multipart_content_type(aos_table_t *headers);
-
-/**
   * @brief  create lifecycle rule content
   * @return lifecycle rule content
 **/

--- a/oss_c_sdk_test/test_oss_bucket.c
+++ b/oss_c_sdk_test/test_oss_bucket.c
@@ -189,7 +189,7 @@ void test_list_object(CuTest *tc)
     params = oss_create_list_object_params(p);
     params->max_ret = 1;
     params->truncated = 0;
-    aos_str_set(&params->prefix, "oss_test");
+    aos_str_set(&params->prefix, "oss_test_object");
     aos_str_set(&bucket, TEST_BUCKET_NAME);
     s = oss_list_object(options, &bucket, params, &resp_headers);
     CuAssertIntEquals(tc, 200, s->code);

--- a/oss_c_sdk_test/test_oss_image.c
+++ b/oss_c_sdk_test/test_oss_image.c
@@ -121,7 +121,7 @@ void test_resize_image(CuTest *tc) {
     get_iamge_info(tc, &image_info);
     CuAssertIntEquals(tc, 100, image_info.height);
     CuAssertIntEquals(tc, 100, image_info.width);
-    CuAssertIntEquals(tc, 3587, image_info.size);
+    CuAssertIntEquals(tc, 3267, image_info.size);
     CuAssertStrEquals(tc, "jpg", image_info.format);
 
     printf("test_resize_image ok\n");
@@ -171,7 +171,7 @@ void test_crop_image(CuTest *tc) {
     get_iamge_info(tc, &image_info);
     CuAssertIntEquals(tc, 100, image_info.height);
     CuAssertIntEquals(tc, 100, image_info.width);
-    CuAssertIntEquals(tc, 2281, image_info.size);
+    CuAssertIntEquals(tc, 1969, image_info.size);
     CuAssertStrEquals(tc, "jpg", image_info.format);
     
     printf("test_crop_image ok\n");
@@ -221,7 +221,7 @@ void test_rotate_image(CuTest *tc) {
     get_iamge_info(tc, &image_info);
     CuAssertIntEquals(tc, 400, image_info.height);
     CuAssertIntEquals(tc, 267, image_info.width);
-    CuAssertIntEquals(tc, 21509, image_info.size);
+    CuAssertIntEquals(tc, 20998, image_info.size);
     CuAssertStrEquals(tc, "jpg", image_info.format);
 
     printf("test_rotate_image ok\n");
@@ -271,7 +271,7 @@ void test_sharpen_image(CuTest *tc) {
     get_iamge_info(tc, &image_info);
     CuAssertIntEquals(tc, 267, image_info.height);
     CuAssertIntEquals(tc, 400, image_info.width);
-    CuAssertIntEquals(tc, 24183, image_info.size);
+    CuAssertIntEquals(tc, 23015, image_info.size);
     CuAssertStrEquals(tc, "jpg", image_info.format);
 
     printf("test_sharpen_image ok\n");
@@ -321,7 +321,7 @@ void test_watermark_image(CuTest *tc) {
     get_iamge_info(tc, &image_info);
     CuAssertIntEquals(tc, 267, image_info.height);
     CuAssertIntEquals(tc, 400, image_info.width);
-    CuAssertIntEquals(tc, 26953, image_info.size);
+    CuAssertIntEquals(tc, 26369, image_info.size);
     CuAssertStrEquals(tc, "jpg", image_info.format);
 
     printf("test_watermark_image ok\n");

--- a/oss_c_sdk_test/test_oss_multipart.c
+++ b/oss_c_sdk_test/test_oss_multipart.c
@@ -149,7 +149,7 @@ void test_multipart_upload(CuTest *tc)
 {
     aos_pool_t *p = NULL;
     aos_string_t bucket;
-    char *object_name = "oss_test_multipart_upload";
+    char *object_name = "oss_test_multipart_upload.js";
     aos_string_t object;
     int is_cname = 0;
     oss_request_options_t *options = NULL;

--- a/oss_c_sdk_test/test_oss_multipart.c
+++ b/oss_c_sdk_test/test_oss_multipart.c
@@ -149,7 +149,7 @@ void test_multipart_upload(CuTest *tc)
 {
     aos_pool_t *p = NULL;
     aos_string_t bucket;
-    char *object_name = "oss_test_multipart_upload.js";
+    char *object_name = "oss_test_multipart_upload";
     aos_string_t object;
     int is_cname = 0;
     oss_request_options_t *options = NULL;
@@ -170,7 +170,7 @@ void test_multipart_upload(CuTest *tc)
     int part_num = 1;
     int part_num1 = 2;
     char *expect_part_num_marker = "1";
-    char *content_type_for_complete = "video/MP2T";
+    char *content_type_for_complete = "application/octet-stream";
     char *actual_content_type = NULL;
 
     aos_pool_create(&p, NULL);


### PR DESCRIPTION
### 变更内容
- oss_init_multipart_upload更加object名字指定content type
- oss_complete_multipart_upload去除`x-oss-replace-object-meta`