### PR TITLE
add the auto-compression support during the data transition

### DIFF
--- a/oss_c_sdk/aos_transport.c
+++ b/oss_c_sdk/aos_transport.c
@@ -241,8 +241,8 @@ size_t aos_curl_default_write_callback(char *ptr, size_t size, size_t nmemb, voi
         aos_move_transport_state(t, TRANS_STATE_BODY_IN);
         return bytes;
     }
-
-    if (t->resp->type == BODY_IN_MEMORY && t->resp->body_len >= (int64_t)t->controller->options->max_memory_size) {
+    
+    if (t->resp->type == BODY_IN_MEMORY && t->resp->body_len >= (int64_t)t->controller->options->max_memory_size) { 
         t->controller->reason = apr_psprintf(t->pool,
              "receive body too big, current body size: %" APR_INT64_T_FMT ", max memory size: %" APR_INT64_T_FMT,
               t->resp->body_len, t->controller->options->max_memory_size);
@@ -384,6 +384,11 @@ int aos_curl_transport_setup(aos_curl_http_transport_t *t)
     curl_easy_setopt_safe(CURLOPT_CONNECTTIMEOUT, t->controller->options->connect_timeout);
     curl_easy_setopt_safe(CURLOPT_LOW_SPEED_LIMIT, t->controller->options->speed_limit);
     curl_easy_setopt_safe(CURLOPT_LOW_SPEED_TIME, t->controller->options->speed_time);
+
+    if (t->controller->options->enable_accept_encoding)
+    {
+        curl_easy_setopt_safe(CURLOPT_ACCEPT_ENCODING, "");
+    }
 
     aos_init_curl_headers(t);
     curl_easy_setopt_safe(CURLOPT_HTTPHEADER, t->headers);

--- a/oss_c_sdk/aos_transport.h
+++ b/oss_c_sdk/aos_transport.h
@@ -34,6 +34,7 @@ struct aos_http_request_options_s {
     int enable_crc;
     char *proxy_host;
     char *proxy_auth;
+    int enable_accept_encoding;  //enable accept-encoding
 };
 
 struct aos_http_transport_options_s {

--- a/oss_c_sdk_sample/oss_get_object_sample.c
+++ b/oss_c_sdk_sample/oss_get_object_sample.c
@@ -121,7 +121,7 @@ void get_object_to_buffer_with_range()
     aos_list_init(&buffer);
     headers = aos_table_make(p, 1);
 
-    /* ����Range����ȡ�ļ���ָ����Χ��bytes=20-100������20�͵�100���ַ� */
+    /* Set range for reading the data. bytes=20-100 means reading the data from the offset 20 to 100 of the file */
     apr_table_set(headers, "Range", "bytes=20-100");
 
     s = oss_get_object_to_buffer(options, &bucket, &object, 
@@ -174,7 +174,7 @@ void get_object_to_local_file_with_range()
     aos_str_set(&file, download_filename);
     headers = aos_table_make(p, 1);
 
-    /* ����Range����ȡ�ļ���ָ����Χ��bytes=20-100������20�͵�100���ַ� */
+    /* Set range for reading the data. bytes=20-100 means reading the data from the offset 20 to 100 of the file */
     apr_table_set(headers, "Range", "bytes=20-100");
 
     s = oss_get_object_to_file(options, &bucket, &object, headers, 

--- a/oss_c_sdk_sample/oss_get_object_sample.c
+++ b/oss_c_sdk_sample/oss_get_object_sample.c
@@ -61,7 +61,7 @@ void get_object_to_buffer()
     aos_pool_destroy(p);
 }
 
-void get_object_to_local_file()
+void get_object_to_local_file(int enable_ae)
 {
     aos_pool_t *p = NULL;
     aos_string_t bucket;
@@ -83,6 +83,7 @@ void get_object_to_local_file()
     headers = aos_table_make(p, 0);
     aos_str_set(&file, download_filename);
 
+    options->ctl->options->enable_accept_encoding = enable_ae;
     s = oss_get_object_to_file(options, &bucket, &object, headers, 
                                params, &file, &resp_headers);
     if (aos_status_is_ok(s)) {
@@ -120,7 +121,7 @@ void get_object_to_buffer_with_range()
     aos_list_init(&buffer);
     headers = aos_table_make(p, 1);
 
-    /* ÉèÖÃRange£¬¶ÁÈ¡ÎÄ¼þµÄÖ¸¶¨·¶Î§£¬bytes=20-100°üÀ¨µÚ20ºÍµÚ100¸ö×Ö·û */
+    /* ï¿½ï¿½ï¿½ï¿½Rangeï¿½ï¿½ï¿½ï¿½È¡ï¿½Ä¼ï¿½ï¿½ï¿½Ö¸ï¿½ï¿½ï¿½ï¿½Î§ï¿½ï¿½bytes=20-100ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½20ï¿½Íµï¿½100ï¿½ï¿½ï¿½Ö·ï¿½ */
     apr_table_set(headers, "Range", "bytes=20-100");
 
     s = oss_get_object_to_buffer(options, &bucket, &object, 
@@ -173,7 +174,7 @@ void get_object_to_local_file_with_range()
     aos_str_set(&file, download_filename);
     headers = aos_table_make(p, 1);
 
-    /* ÉèÖÃRange£¬¶ÁÈ¡ÎÄ¼þµÄÖ¸¶¨·¶Î§£¬bytes=20-100°üÀ¨µÚ20ºÍµÚ100¸ö×Ö·û */
+    /* ï¿½ï¿½ï¿½ï¿½Rangeï¿½ï¿½ï¿½ï¿½È¡ï¿½Ä¼ï¿½ï¿½ï¿½Ö¸ï¿½ï¿½ï¿½ï¿½Î§ï¿½ï¿½bytes=20-100ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½20ï¿½Íµï¿½100ï¿½ï¿½ï¿½Ö·ï¿½ */
     apr_table_set(headers, "Range", "bytes=20-100");
 
     s = oss_get_object_to_file(options, &bucket, &object, headers, 
@@ -324,7 +325,8 @@ void get_oss_dir_to_local_dir()
 void get_object_sample()
 {
     get_object_to_buffer();
-    get_object_to_local_file();
+    get_object_to_local_file(0); 
+    get_object_to_local_file(1); 
 
     get_object_to_buffer_with_range();
     get_object_to_local_file_with_range();

--- a/oss_c_sdk_test/test_oss_object.c
+++ b/oss_c_sdk_test/test_oss_object.c
@@ -199,8 +199,9 @@ void test_put_object_from_buffer_with_specified(CuTest *tc)
     printf("test_put_object_from_buffer_with_specified ok\n");
 }
 
-void test_put_object_from_file(CuTest *tc)
+void test_put_object_from_file(CuTest *tc, int enable_ae)
 {
+    printf("start test_put_object_from_file %d",enable_ae);
     aos_pool_t *p = NULL;
     char *object_name = "video_1.ts";
     char *filename = __FILE__;
@@ -217,6 +218,7 @@ void test_put_object_from_file(CuTest *tc)
     aos_pool_create(&p, NULL);
     options = oss_request_options_create(p);
     init_test_request_options(options, is_cname);
+    options->ctl->options->enable_accept_encoding = enable_ae;
     headers = aos_table_make(p, 5);
     s = create_test_object_from_file(options, TEST_BUCKET_NAME, 
             object_name, filename, headers);
@@ -239,7 +241,17 @@ void test_put_object_from_file(CuTest *tc)
     content_type = (char*)(apr_table_get(head_resp_headers, OSS_CONTENT_TYPE));
     CuAssertStrEquals(tc, "application/octet-stream", content_type);
 
-    printf("test_put_object_from_file ok\n");
+    printf("test_put_object_from_file %d ok\n", enable_ae);
+}
+
+void test_put_object_from_file_with_te(CuTest *tc)
+{
+    test_put_object_from_file(tc, 1);
+}
+
+void test_put_object_from_file_without_te(CuTest *tc)
+{
+    test_put_object_from_file(tc, 0);
 }
 
 void test_put_object_with_large_length_header(CuTest *tc)
@@ -432,7 +444,7 @@ void test_get_object_to_buffer_with_range(CuTest *tc)
     printf("test_get_object_to_buffer_with_range ok\n");
 }
 
-void test_get_object_to_file(CuTest *tc)
+void test_get_object_to_file(CuTest *tc, int enable_ae)
 {
     aos_pool_t *p = NULL;
     aos_string_t bucket;
@@ -452,6 +464,7 @@ void test_get_object_to_file(CuTest *tc)
     aos_pool_create(&p, NULL);
     options = oss_request_options_create(p);
     init_test_request_options(options, is_cname);
+    options->ctl->options->enable_accept_encoding = enable_ae;
     aos_str_set(&bucket, TEST_BUCKET_NAME);
     aos_str_set(&object, object_name);
     aos_str_set(&file, filename);
@@ -468,7 +481,17 @@ void test_get_object_to_file(CuTest *tc)
     remove(filename);
     aos_pool_destroy(p);
 
-    printf("test_get_object_to_file ok\n");
+    printf("test_get_object_to_file %d ok\n", enable_ae);
+}
+
+void test_get_object_to_file_with_te(CuTest *tc)
+{
+    test_get_object_to_file(tc,1);
+}
+
+void test_get_object_to_file_without_te(CuTest *tc)
+{
+    test_get_object_to_file(tc,0);
 }
 
 void test_head_object(CuTest *tc)
@@ -933,14 +956,16 @@ CuSuite *test_oss_object()
 
     SUITE_ADD_TEST(suite, test_object_setup);
     SUITE_ADD_TEST(suite, test_put_object_from_buffer);
-    SUITE_ADD_TEST(suite, test_put_object_from_file);
+    SUITE_ADD_TEST(suite, test_put_object_from_file_with_te);
+    SUITE_ADD_TEST(suite, test_put_object_from_file_without_te);
     SUITE_ADD_TEST(suite, test_put_object_from_buffer_with_specified);
     SUITE_ADD_TEST(suite, test_get_object_to_buffer);
     SUITE_ADD_TEST(suite, test_get_object_to_buffer_with_range);
     SUITE_ADD_TEST(suite, test_put_object_from_file_with_content_type);
     SUITE_ADD_TEST(suite, test_put_object_from_buffer_with_default_content_type);
     SUITE_ADD_TEST(suite, test_put_object_with_large_length_header);
-    SUITE_ADD_TEST(suite, test_get_object_to_file);
+    SUITE_ADD_TEST(suite, test_get_object_to_file_with_te);
+    SUITE_ADD_TEST(suite, test_get_object_to_file_without_te);
     SUITE_ADD_TEST(suite, test_head_object);
     SUITE_ADD_TEST(suite, test_head_object_with_not_exist);
     SUITE_ADD_TEST(suite, test_copy_object);


### PR DESCRIPTION
Add the option enable_accept_encoding to enable auto-compression support.