### PR TITLE
crc64: use pthread_once() if available

### DIFF
--- a/oss_c_sdk/aos_define.h
+++ b/oss_c_sdk/aos_define.h
@@ -8,6 +8,7 @@
 #include <ctype.h>
 #include <time.h>
 
+#include <apr_portable.h>
 #include <apr_time.h>
 #include <apr_strings.h>
 #include <apr_pools.h>


### PR DESCRIPTION
crc64 code defines ONCE() macro to do dynamic initialization, and when
pthread is not available ONCE() is a simple and thread-unsafe version,
this may lead to race condition in multi-thread environments,
crc64_little_init() may hit infinit loop in ONCE().

We need to include apr_portable.h, which includes pthread.h if
APR_HAVE_PTHREAD_H is defined.

Fixes: #81
Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>